### PR TITLE
Feat: 식단 조회 API 인터페이스 변경

### DIFF
--- a/controller/school_controller.go
+++ b/controller/school_controller.go
@@ -33,6 +33,11 @@ func NewSchoolController(svc service.SchoolService) SchoolContoller {
 func (ctl *schoolContoller) List(c *fiber.Ctx) error {
 	keyword := c.Query("keyword")
 
+	// Validate Request
+	if keyword == "" {
+		return ErrorOf(fiber.StatusBadRequest, "40000", MessageOfCode(fiber.StatusBadRequest))
+	}
+
 	schools, err := ctl.svc.GetSchools(keyword)
 	if err != nil {
 		log.Println(err)
@@ -59,6 +64,16 @@ func (ctl *schoolContoller) ListMeals(c *fiber.Ctx) error {
 	from := c.Query(("from"))
 	to := c.Query(("to"))
 
+	// Validate Request
+	if eduOfficeCode == "" || schoolCode == "" || from == "" || to == "" {
+		return ErrorOf(fiber.StatusBadRequest, "40000", MessageOfCode(fiber.StatusBadRequest))
+	}
+
+	fromTime, fromTimeErr := time.Parse("2006-01-02", from)
+	toTime, toTimeErr := time.Parse("2006-01-02", to)
+	if fromTimeErr != nil || toTimeErr != nil {
+		return ErrorOf(fiber.StatusBadRequest, "40000", MessageOfCode(fiber.StatusBadRequest))
+	}
 
 	meals, err := ctl.svc.GetMealPlans(eduOfficeCode, schoolCode, fromTime, toTime)
 	if err != nil {

--- a/controller/school_controller.go
+++ b/controller/school_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"0tak2/afterhee-server/service"
 	"log"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
 )
@@ -48,17 +49,18 @@ func (ctl *schoolContoller) List(c *fiber.Ctx) error {
 //	@Produce		json
 //	@Param			eduOfficeCode	query	string	true	"시도교육청코드"
 //	@Param			schoolCode	query	string	true	"학교 행정표준코드"
-//	@Param			year	query	string	true	"요청하려는 연도 (YYYY)"
-//	@Param			month	query	string	true	"요청하려는 달 (MM)"
+//	@Param			from	query	string	true	"요청하려는 시작 일자 (YYYY-MM-DD)"
+//	@Param			to	query	string	true	"요청하려는 종료 일자 (YYYY-MM-DD)"
 //	@Success 200 {object} controller.CommonResponse{data=[]service.Meal}
 //	@Router			/api/v1/schools/meals [get]
 func (ctl *schoolContoller) ListMeals(c *fiber.Ctx) error {
 	eduOfficeCode := c.Query("eduOfficeCode")
 	schoolCode := c.Query("schoolCode")
-	year := c.Query(("year"))
-	month := c.Query(("month"))
+	from := c.Query(("from"))
+	to := c.Query(("to"))
 
-	meals, err := ctl.svc.GetMealPlans(eduOfficeCode, schoolCode, year, month)
+
+	meals, err := ctl.svc.GetMealPlans(eduOfficeCode, schoolCode, fromTime, toTime)
 	if err != nil {
 		log.Println(err)
 		return ErrorOf(fiber.StatusInternalServerError, "50000", MessageOfCode(fiber.StatusInternalServerError))

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -86,15 +86,15 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "요청하려는 연도 (YYYY)",
-                        "name": "year",
+                        "description": "요청하려는 시작 일자 (YYYY-MM-DD)",
+                        "name": "from",
                         "in": "query",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "description": "요청하려는 달 (MM)",
-                        "name": "month",
+                        "description": "요청하려는 종료 일자 (YYYY-MM-DD)",
+                        "name": "to",
                         "in": "query",
                         "required": true
                     }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -80,15 +80,15 @@
                     },
                     {
                         "type": "string",
-                        "description": "요청하려는 연도 (YYYY)",
-                        "name": "year",
+                        "description": "요청하려는 시작 일자 (YYYY-MM-DD)",
+                        "name": "from",
                         "in": "query",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "description": "요청하려는 달 (MM)",
-                        "name": "month",
+                        "description": "요청하려는 종료 일자 (YYYY-MM-DD)",
+                        "name": "to",
                         "in": "query",
                         "required": true
                     }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -109,14 +109,14 @@ paths:
         name: schoolCode
         required: true
         type: string
-      - description: 요청하려는 연도 (YYYY)
+      - description: 요청하려는 시작 일자 (YYYY-MM-DD)
         in: query
-        name: year
+        name: from
         required: true
         type: string
-      - description: 요청하려는 달 (MM)
+      - description: 요청하려는 종료 일자 (YYYY-MM-DD)
         in: query
-        name: month
+        name: to
         required: true
         type: string
       produces:

--- a/network/neis_meal.go
+++ b/network/neis_meal.go
@@ -3,10 +3,12 @@ package network
 import (
 	"0tak2/afterhee-server/configuration"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"net/url"
+	"regexp"
 )
 
 const neisBaseURL = "https://open.neis.go.kr/hub"
@@ -16,7 +18,7 @@ type NEISMealRequest interface {
 	// schoolAdminCode 학교 행정표준코드
 	// year 요청 연도
 	// month 요청 월
-	FetchMealPlan(eduOfficeCode string, schoolAdminCode string, year string, month string) (*MealServiceDietInfoResponse, error)
+	FetchMealPlan(eduOfficeCode string, schoolAdminCode string, fromDateString string, toDateString string) (*MealServiceDietInfoResponse, error)
 }
 
 type neisMealRequest struct {
@@ -26,8 +28,15 @@ func NewNEISMealRequest() NEISMealRequest {
 	return &neisMealRequest{}
 }
 
-func (r neisMealRequest) FetchMealPlan(eduOfficeCode string, schoolAdminCode string, year string, month string) (*MealServiceDietInfoResponse, error) {
+func (r neisMealRequest) FetchMealPlan(eduOfficeCode string, schoolAdminCode string, fromDateString string, toDateString string) (*MealServiceDietInfoResponse, error) {
 	config := configuration.GetConfiguration()
+
+	// Validate Date String
+	var dateRegex = regexp.MustCompile(`^\d{8}$`)
+
+	if !dateRegex.MatchString(fromDateString) || !dateRegex.MatchString(toDateString) {
+		return nil, fmt.Errorf("invalid date format: must be YYYYMMDD")
+	}
 
 	destination, _ := url.Parse(neisBaseURL + "/mealServiceDietInfo")
 
@@ -36,7 +45,8 @@ func (r neisMealRequest) FetchMealPlan(eduOfficeCode string, schoolAdminCode str
 	params.Add("Type", "json")
 	params.Add("ATPT_OFCDC_SC_CODE", eduOfficeCode)
 	params.Add("SD_SCHUL_CODE", schoolAdminCode)
-	params.Add("MLSV_YMD", year+month)
+	params.Add("MLSV_FROM_YMD", fromDateString)
+	params.Add("MLSV_TO_YMD", toDateString)
 
 	destination.RawQuery = params.Encode()
 

--- a/service/school_service.go
+++ b/service/school_service.go
@@ -5,6 +5,7 @@ import (
 	"0tak2/afterhee-server/repository"
 	"errors"
 	"log"
+	"time"
 )
 
 // Domain Entity
@@ -39,7 +40,7 @@ type Meal struct {
 // Service
 type SchoolService interface {
 	GetSchools(keyword string) ([]School, error)
-	GetMealPlans(sidoEduOfficeCode string, schoolStandardCode string, year string, month string) ([]Meal, error)
+	GetMealPlans(sidoEduOfficeCode string, schoolStandardCode string, from time.Time, to time.Time) ([]Meal, error)
 }
 
 type schoolService struct {
@@ -77,8 +78,8 @@ func (s schoolService) GetSchools(keyword string) ([]School, error) {
 	return schools, err
 }
 
-func (s schoolService) GetMealPlans(sidoEduOfficeCode string, schoolStandardCode string, year string, month string) ([]Meal, error) {
-	result, err := s.neis.FetchMealPlan(sidoEduOfficeCode, schoolStandardCode, year, month)
+func (s schoolService) GetMealPlans(sidoEduOfficeCode string, schoolStandardCode string, from time.Time, to time.Time) ([]Meal, error) {
+	result, err := s.neis.FetchMealPlan(sidoEduOfficeCode, schoolStandardCode, timeToString(from), timeToString((to)))
 	if err != nil {
 		return nil, err
 	}
@@ -111,4 +112,8 @@ func (s schoolService) GetMealPlans(sidoEduOfficeCode string, schoolStandardCode
 		})
 	}
 	return meals, err
+}
+
+func timeToString(time time.Time) string {
+	return time.Format("20060102")
 }


### PR DESCRIPTION
## 📌 PR 제목
<!-- 간결하고 명확하게 작성 -->

Feat: 식단 조회 API 인터페이스 변경

---

## 📝 개요
<!-- 변경 내용과 목적을 간략히 설명 -->
 
- 현재 날짜가 8월 1일인 경우, 7월 31일과 8월 2일의 식단이 필요
- 기존에는 식단 요청 API가 월별로 식단을 내려주고 있었기 때문에 두 번 요청해야함
- NEIS에 시작일, 종료일로 요청하는 방법을 확인하고 거기에 맞게 변경

---

## 🔄 변경 사항
<!-- 주요 변경 내용 목록 -->
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가/수정
- [x] 인터페이스 변경
    - 기존: `/api/v1/schools/meals?eduOfficeCode=B10&schoolCode=7010266&year=2025&month=08`
    - 변경: `/api/v1/schools/meals?eduOfficeCode=B10&schoolCode=7010266&from=2025-07-30&to=2025-08-02`
        - \* 반드시 날짜 형식은 YYYY-MM-DD로 요청. 틀리면 400 Bad Request

---

## ✅ 체크리스트
- [x] 코드 스타일 가이드 준수
- [x] 기존 기능 정상 동작 확인
- [ ] 새로운 기능/수정 사항에 대한 테스트 작성 및 통과
- [x] 관련 문서 업데이트

---

## 📎 참고 사항
<!-- 연관된 이슈 번호, 참고 링크 등 -->
- Closes #1 
- Related to #
