### PR TITLE
Fix: validateCategory 허용 카테고리 이름 수정, 프롬프팅 개선

### DIFF
--- a/controller/suggest_controller.go
+++ b/controller/suggest_controller.go
@@ -34,7 +34,7 @@ func NewSuggestController(svc service.GeminiService) SuggestContoller {
 // Suggest godoc
 //
 //	@Summary		메뉴 제안
-//	@Description	메뉴를 제안한다
+//	@Description	메뉴를 제안한다. category는 다음만 허용한다: "한식", "일식", "중식", "양식", "아시안", "세계음식", "찜", "국물", "볶음", "밥", "면", "빵", "해물", "고기", "야채", "빠른 식사", "디저트",
 //	@Accept			json
 //	@Produce		json
 //	@Param request body SuggestMenuRequest true "request suggest menu body"
@@ -74,8 +74,8 @@ func (ctl *suggestContoller) Suggest(c *fiber.Ctx) error {
 
 // SuggestTest godoc
 //
-//	@Summary		메뉴 제안
-//	@Description	메뉴를 제안한다
+//	@Summary		매뉴얼 프롬프트 테스팅
+//	@Description	프롬프트로 LLM에 요청을 보낸다.
 //	@Accept			json
 //	@Produce		json
 //	@Param request body SuggestTestRequest true "request suggest menu body"
@@ -109,8 +109,8 @@ func (ctl *suggestContoller) SuggestTest(c *fiber.Ctx) error {
 func validateCategory(rawCategory string) bool {
 	allowCategories := []string{
 		"한식", "일식", "중식", "양식", "아시안",
-		"세계음식", "찜", "국물", "볶음", "밥요리",
-		"면요리", "빵", "해물", "고기", "야채",
+		"세계음식", "찜", "국물", "볶음", "밥",
+		"면", "빵", "해물", "고기", "야채",
 		"빠른 식사", "디저트",
 	}
 

--- a/network/gemini.go
+++ b/network/gemini.go
@@ -87,7 +87,30 @@ func (r geminiRequest) requestToGemini(prompt string) (*GeminiMenuRecommendation
 	return &response, nil
 }
 
+func preprocessLLMInputs(values GeminiMenuRecommendationPromptValues) GeminiMenuRecommendationPromptValues {
+	switch values.Category {
+	case "아시안":
+		values.Category = "인도 음식, 태국 음식, 베트남 음식, 네팔 음식, 몽골 음식"
+	case "세계음식":
+		values.Category = "터키 등 중동 음식, 멕세코 등 남미 음식, 샤실리크 등 러시아 음식, 그 외 아시안 음식을 제외한 세계 음식"
+	case "볶음":
+		values.Category = "볶음 요리"
+	case "밥":
+		values.Category = "덮밥, 비빔밥, 볶음밥 등 각종 밥 요리"
+	case "면":
+		values.Category = "면 요리"
+	case "야채":
+		values.Category = "샐러드, 포케 등 야채가 풍부하게 들어간 음식"
+	case "빠른 식사":
+		values.Category = "분식, 햄버거, 샌드위치 등 빠르게 주문해서 먹을 수 있는 음식. 컵밥은 제외."
+	}
+
+	return values
+}
+
 func CreatePrompt(values GeminiMenuRecommendationPromptValues) (*string, error) {
+	processedValues := preprocessLLMInputs(values)
+
 	tmpl := `Recommend one new menu item that falls under the following category and is not included in the exclusion menu, along with the reason. Please respond in Korean.
 
 Category: {{ .Category }}
@@ -97,7 +120,7 @@ Exclusion Menu: {{range .SkipMenus}}{{.}}, {{end}}
 	t := template.Must(template.New("MenuRecommendRequestPrompt").Parse(tmpl))
 
 	var buf bytes.Buffer
-	if err := t.Execute(&buf, values); err != nil {
+	if err := t.Execute(&buf, processedValues); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## 📌 PR 제목
<!-- 간결하고 명확하게 작성 -->
validateCategory 허용 카테고리 이름 수정, 프롬프팅 개선
---

## 📝 개요
<!-- 변경 내용과 목적을 간략히 설명 -->
- 메뉴 추천 시 허용 카테고리 픽스
    - 밥요리 -> 밥
    - 면요리 -> 면
- 프롬프팅 개선
    - 다음의 카테고리로 요청했을 때 내부 프롬프팅
        - 아시안 -> 인도 음식, 태국 음식, 베트남 음식, 네팔 음식, 몽골 음식
        - 세계음식 -> 터키 등 중동 음식, 멕세코 등 남미 음식, 샤실리크 등 러시아 음식, 그 외 아시안 음식을 제외한 세계 음식
        - 볶음 -> 볶음 요리
        - 밥 -> 덮밥, 비빔밥, 볶음밥 등 각종 밥 요리
        - 면 -> 면 요리
        - 야채 -> 샐러드, 포케 등 야채가 풍부하게 들어간 음식
        - 빠른 식사 -> 분식, 햄버거, 샌드위치 등 빠르게 주문해서 먹을 수 있는 음식. 컵밥은 제외.
            - 컵밥이 너무 자주 나오는 경향이 있어 컵밥을 의도적으로 제외함.
    - 프롬프팅 개선은 앞으로도 수시로 이뤄질 수 있음
    - 예시 (카테고리=아시안, 제외메뉴=김치,밥,탕수육,팟타이,청경채,계란국)
        - 실제 입력 프롬프트
             ```json
                  Recommend one new menu item that falls under the following category and is not included in the exclusion menu, along with the reason. Please respond in Korean.
                  
                  Category: 인도 음식, 태국 음식, 베트남 음식, 네팔 음식, 몽골 음식
                  Exclusion Menu: 김치, 밥, 탕수육, 팟타이, 청경채, 계란국,
             ```
        - 응답
             ```json
              {
                "isError": false,
                "message": "요청을 잘 수행했습니다",
                "data": {
                  "recommendation": "탄두리 치킨",
                  "reason": "인도 전통 방식의 탄두르 오븐에서 구워내어 특유의 향과 부드러운 육질이 일품이며, 건강하고 이국적인 맛을 찾는 고객들에게 큰 인기를 얻을 수 있습니다."
                }
              }
             ```
---

## 🔄 변경 사항
<!-- 주요 변경 내용 목록 -->
- [x] 기능 추가
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가/수정

---

## ✅ 체크리스트
- [x] 코드 스타일 가이드 준수
- [x] 기존 기능 정상 동작 확인
- [] 새로운 기능/수정 사항에 대한 테스트 작성 및 통과
- [ ] 관련 문서 업데이트

---

## 📎 참고 사항
<!-- 연관된 이슈 번호, 참고 링크 등 -->
- Closes #16
- Related to #
