### PR TITLE
Fix: NEIS에서 반환하는 식단 정보가 없으면 빈 슬라이스 반환

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- NEIS에서 반환하는 식단 정보가 완전히 없으면 오류를 반환하던 문제
+
 ### Security
 
 ## [0.0.6] - 2026-02-07

--- a/service/school_service.go
+++ b/service/school_service.go
@@ -5,7 +5,6 @@ import (
 	"0tak2/afterhee-server/repository"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"sort"
@@ -109,7 +108,7 @@ func (s schoolService) GetMealPlans(ctx context.Context, sidoEduOfficeCode strin
 	}
 
 	if len(result.MealServiceDietInfo) < 2 {
-		return nil, errors.New("no meal rows") // TODO: Custom Error
+		return []Meal{}, nil
 	}
 
 	rows := result.MealServiceDietInfo[1].Row

--- a/service/school_service_test.go
+++ b/service/school_service_test.go
@@ -109,7 +109,7 @@ func TestSchoolService_GetMealPlans(t *testing.T) {
 		mockCache.AssertCalled(t, "SetValue", ctx, mock.Anything, mock.Anything, mock.Anything)
 	})
 
-	t.Run("급식 정보가 없는 경우 에러를 반환한다", func(t *testing.T) {
+	t.Run("급식 정보가 없는 경우 빈 슬라이스를 반환한다", func(t *testing.T) {
 		mockCache := new(extendedMockCache)
 		mockNEIS := new(mockNEISRequest)
 		service := NewSchoolService(nil, mockCache, mockNEIS)
@@ -129,8 +129,7 @@ func TestSchoolService_GetMealPlans(t *testing.T) {
 
 		result, err := service.GetMealPlans(ctx, sidoCode, schoolCode, from, to)
 
-		assert.Error(t, err)
-		assert.Equal(t, "no meal rows", err.Error())
-		assert.Nil(t, result)
+		assert.Len(t, result, 0)
+		assert.Nil(t, err)
 	})
 }


### PR DESCRIPTION
## 📌 PR 제목
<!-- 간결하고 명확하게 작성 -->

NEIS에서 반환하는 식단 정보가 없으면 빈 슬라이스 반환

---

## 📝 개요
<!-- 변경 내용과 목적을 간략히 설명 -->
- 

- NEIS에서 반환하는 식단 정보가 없으면 에러를 반환했으나, 빈 슬라이스 반환하도록 수정했습니다
- 이 문제는 그 동안 알려져있지 않다가, 최근 방학 기간 테스트해보면서, 모든 기간 식단 정보가 존재하지 않게 되자, 오류가 발생하는 것을 알게되면서 수정했습니다.

---

## 🔄 변경 사항
<!-- 주요 변경 내용 목록 -->
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가/수정

---

## ✅ 체크리스트
- [ ] 코드 스타일 가이드 준수
- [ ] 기존 기능 정상 동작 확인
- [ ] 새로운 기능/수정 사항에 대한 테스트 작성 및 통과
- [ ] 관련 문서 업데이트

---

## 📎 참고 사항
<!-- 연관된 이슈 번호, 참고 링크 등 -->
- Closes #46
- Related to #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed an issue where completely empty meal information caused an error. The system now returns an empty result gracefully instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->