### PR TITLE
Fix: NEIS에서 반환하는 식단 정보가 빈 슬라이스여도 Redis에 저장

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- 식단 조회 캐싱 시, TTL을 기존 3일에서 1일로 변경
+
 ### Deprecated
                                                   
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- NEIS에서 반환하는 식단 정보가 완전히 없으면 오류를 반환하던 문제
+- NEIS에서 반환하는 식단 정보가 빈 슬라이스여도 Redis에 저장
 
 ### Security
 

--- a/service/school_service.go
+++ b/service/school_service.go
@@ -144,7 +144,7 @@ func (s schoolService) GetMealPlans(ctx context.Context, sidoEduOfficeCode strin
 	if marshalErr != nil {
 		log.Printf("failed to marshal data that will be planned to cache. skip cache it. error=%s", marshalErr.Error())
 	} else {
-		ttl := 3 * 24 * time.Hour
+		ttl := 24 * time.Hour
 		if err := s.cache.SetValue(ctx, cacheKey, string(jsonBytes), ttl); err != nil {
 			log.Printf("failed to cache meal plans: %v", err)
 		}

--- a/service/school_service.go
+++ b/service/school_service.go
@@ -107,11 +107,12 @@ func (s schoolService) GetMealPlans(ctx context.Context, sidoEduOfficeCode strin
 		return nil, err
 	}
 
+	var rows []network.MealRow
 	if len(result.MealServiceDietInfo) < 2 {
-		return []Meal{}, nil
+		rows = []network.MealRow{}
+	} else {
+		rows = result.MealServiceDietInfo[1].Row
 	}
-
-	rows := result.MealServiceDietInfo[1].Row
 
 	var meals []Meal
 	for _, row := range rows {


### PR DESCRIPTION
## 📌 PR 제목
<!-- 간결하고 명확하게 작성 -->

NEIS에서 반환하는 식단 정보가 빈 슬라이스여도 Redis에 저장

---

## 📝 개요
<!-- 변경 내용과 목적을 간략히 설명 -->
- NEIS에서 반환하는 식단 정보가 빈 슬라이스여도 Redis에 저장하여 클라이언트에서 재요청시 NEIS에 요청하지 않게 했습니다
- 캐시 TTL을 하루로 바꾸었습니다. 어짜피 다음 날이 되면 캐시 키가 달라져 사용이 불가능하기 때문입니다.
- 하루마다 별도의 캐시 키로 저장하고, 반환 시 어그리게이트하는 방식도 고민해볼만할 것 같습니다.

---

## 🔄 변경 사항
<!-- 주요 변경 내용 목록 -->
- [x] 기능 추가
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가/수정

---

## ✅ 체크리스트
- [ ] 코드 스타일 가이드 준수
- [ ] 기존 기능 정상 동작 확인
- [ ] 새로운 기능/수정 사항에 대한 테스트 작성 및 통과
- [ ] 관련 문서 업데이트

---

## 📎 참고 사항
<!-- 연관된 이슈 번호, 참고 링크 등 -->
- Closes #51
- Related to #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Reduced meal plan cache refresh interval from 3 days to 1 day for more current data availability.
  * Improved handling of empty meal data responses to gracefully process information instead of displaying errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->