### PR TITLE
Hotfix: NEIS에서 반환하는 식단 정보가 빈 슬라이스일 때, []이 아닌 nil을 반환했던 문제 수정

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.0.9] - 2026-02-07
+
+### Fixed
+
+- NEIS에서 반환하는 식단 정보가 빈 슬라이스일 때, []이 아닌 nil을 반환했던 문제 수정
+
 ## [0.0.8] - 2026-02-07
 
 ### Changed
@@ -74,7 +80,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 기본 엔드포인트 구현
 
-[unreleased]: https://github.com/AfterHee/afterhee-server/compare/v0.0.8...HEAD
+[unreleased]: https://github.com/AfterHee/afterhee-server/compare/v0.0.9...HEAD
+[0.0.9]: https://github.com/AfterHee/afterhee-server/releases/tag/v0.0.9
 [0.0.8]: https://github.com/AfterHee/afterhee-server/releases/tag/v0.0.8
 [0.0.7]: https://github.com/AfterHee/afterhee-server/releases/tag/v0.0.7
 [0.0.6]: https://github.com/AfterHee/afterhee-server/releases/tag/v0.0.6

--- a/service/school_service.go
+++ b/service/school_service.go
@@ -89,7 +89,7 @@ func (s schoolService) GetSchools(keyword string) ([]School, error) {
 
 func (s schoolService) GetMealPlans(ctx context.Context, sidoEduOfficeCode string, schoolStandardCode string, from time.Time, to time.Time) ([]Meal, error) {
 	// Fetch cached data
-	cacheKey := fmt.Sprintf("%s_%s_%d_%d", sidoEduOfficeCode, schoolStandardCode, from.Unix(), to.Unix())
+	cacheKey := s.getMealCacheKey(sidoEduOfficeCode, schoolStandardCode, from, to)
 	cachedValue, cacheFetchErr := s.cache.GetValue(ctx, cacheKey)
 
 	if cacheFetchErr == nil && cachedValue != nil {
@@ -107,13 +107,13 @@ func (s schoolService) GetMealPlans(ctx context.Context, sidoEduOfficeCode strin
 		return nil, err
 	}
 
-	var rows []network.MealRow
 	if len(result.MealServiceDietInfo) < 2 {
-		rows = []network.MealRow{}
-	} else {
-		rows = result.MealServiceDietInfo[1].Row
+		emptyValue := []Meal{}
+
+		return emptyValue, nil
 	}
 
+	rows := result.MealServiceDietInfo[1].Row
 	var meals []Meal
 	for _, row := range rows {
 		log.Println(row)
@@ -151,6 +151,23 @@ func (s schoolService) GetMealPlans(ctx context.Context, sidoEduOfficeCode strin
 	}
 
 	return meals, nil
+}
+
+func (s schoolService) getMealCacheKey(sidoEduOfficeCode string, schoolStandardCode string, from time.Time, to time.Time) string {
+	return fmt.Sprintf("%s_%s_%d_%d", sidoEduOfficeCode, schoolStandardCode, from.Unix(), to.Unix())
+}
+
+func (s schoolService) setMealCache(ctx context.Context, sidoEduOfficeCode string, schoolStandardCode string, from time.Time, to time.Time, meals []Meal) {
+	cacheKey := s.getMealCacheKey(sidoEduOfficeCode, schoolStandardCode, from, to)
+	jsonBytes, marshalErr := json.Marshal(meals)
+	if marshalErr != nil {
+		log.Printf("failed to marshal data that will be planned to cache. skip cache it. error=%s", marshalErr.Error())
+	} else {
+		ttl := 24 * time.Hour
+		if err := s.cache.SetValue(ctx, cacheKey, string(jsonBytes), ttl); err != nil {
+			log.Printf("failed to cache meal plans: %v", err)
+		}
+	}
 }
 
 func timeToString(time time.Time) string {


### PR DESCRIPTION
## 📌 PR 제목
<!-- 간결하고 명확하게 작성 -->

NEIS에서 반환하는 식단 정보가 빈 슬라이스일 때, []이 아닌 nil을 반환했던 문제 수정

---

## 📝 개요
<!-- 변경 내용과 목적을 간략히 설명 -->
- NEIS에서 반환하는 식단 정보가 빈 슬라이스일 때, []이 아닌 nil을 반환했던 문제 수정
- nil을 반환하면 역시 앱에서 제대로 렌더링이 안됨

---

## 🔄 변경 사항
<!-- 주요 변경 내용 목록 -->
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가/수정

---

## ✅ 체크리스트
- [ ] 코드 스타일 가이드 준수
- [ ] 기존 기능 정상 동작 확인
- [ ] 새로운 기능/수정 사항에 대한 테스트 작성 및 통과
- [ ] 관련 문서 업데이트

---

## 📎 참고 사항
<!-- 연관된 이슈 번호, 참고 링크 등 -->
- Closes #56
- Related to #
